### PR TITLE
Optimize JSON Tree Search and Sidebar Functionality

### DIFF
--- a/JSONViewer/UI/AppShellView.swift
+++ b/JSONViewer/UI/AppShellView.swift
@@ -46,19 +46,18 @@ struct AppShellView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
 
                     if viewModel.mode != .none {
-                        CommandBarView(
+                        CommandBarContainer(
                             mode: $viewModel.commandMode,
-                            text: $viewModel.commandText,
                             placeholder: viewModel.commandMode == .jq
                                 ? "jq filter (e.g. .items | length)"
                                 : "Use natural language to search or transform"
-                        ) {
+                        ) { text in
                             switch viewModel.commandMode {
                             case .jq:
-                                viewModel.runJQ(filter: viewModel.commandText)
+                                viewModel.runJQ(filter: text)
                             case .ai:
                                 withAnimation { isAISidebarVisible = true }
-                                viewModel.runAI(prompt: viewModel.commandText)
+                                viewModel.runAI(prompt: text)
                             }
                         }
                     }
@@ -262,5 +261,23 @@ struct AppShellView: View {
         #if os(macOS)
         NSWorkspace.shared.activateFileViewerSelecting([url])
         #endif
+    }
+}
+
+private struct CommandBarContainer: View {
+    @Binding var mode: CommandBarView.Mode
+    var placeholder: String
+    var onRun: (String) -> Void
+
+    @State private var textLocal: String = ""
+
+    var body: some View {
+        CommandBarView(
+            mode: $mode,
+            text: $textLocal,
+            placeholder: placeholder
+        ) {
+            onRun(textLocal)
+        }
     }
 }

--- a/JSONViewer/UI/JSONTreeView.swift
+++ b/JSONViewer/UI/JSONTreeView.swift
@@ -6,6 +6,14 @@ struct JSONTreeView: View {
     var onSelect: (JSONTreeNode) -> Void
     @FocusState private var findFocused: Bool
 
+    // Cache heavy rows computation so arbitrary AppViewModel changes (e.g. typing in AI/JQ)
+    // don't trigger an expensive full-tree traversal on every keystroke.
+    @State private var cachedRows: [RowItem] = []
+    @State private var lastRootId: UUID? = nil
+    @State private var lastQuery: String = ""
+    @State private var lastExpanded: Set<String> = []
+    @State private var queryDebounce: Task<Void, Never>? = nil
+
     private struct RowItem: Identifiable, Hashable {
         let id: UUID = UUID()
         let node: JSONTreeNode
@@ -42,8 +50,12 @@ struct JSONTreeView: View {
         return result
     }
 
-    private var visibleRows: [RowItem] {
-        guard let root else { return [] }
+    private func recomputeRows() {
+        guard let root else {
+            cachedRows = []
+            lastRootId = nil
+            return
+        }
         let q = viewModel.treeSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let autoExpand = ancestorPathsForMatches(root: root, query: q)
         let expansionSet = viewModel.expandedPaths.union(autoExpand)
@@ -60,13 +72,15 @@ struct JSONTreeView: View {
         walk(root, depth: 0)
 
         if q.isEmpty {
-            return rows
+            cachedRows = rows
         } else {
-            // Filter out branches unrelated to matches, but keep ancestors (autoExpand)
-            return rows.filter { item in
+            cachedRows = rows.filter { item in
                 nodeMatches(item.node, query: q) || autoExpand.contains(item.node.path)
             }
         }
+        lastRootId = root.id
+        lastQuery = q
+        lastExpanded = viewModel.expandedPaths
     }
 
     private func toggle(_ node: JSONTreeNode) {
@@ -142,7 +156,7 @@ struct JSONTreeView: View {
 
                     ScrollView {
                         LazyVStack(alignment: .leading, spacing: 4) {
-                            ForEach(visibleRows) { item in
+                            ForEach(cachedRows) { item in
                                 JSONTreeRowView(
                                     node: item.node,
                                     depth: item.depth,
@@ -163,6 +177,20 @@ struct JSONTreeView: View {
                 .onChange(of: viewModel.treeFindFocusToken) { _ in
                     findFocused = true
                 }
+                .onChange(of: viewModel.treeSearchQuery) { _ in
+                    // Debounce heavy search recomputation to keep typing fluid on large trees.
+                    queryDebounce?.cancel()
+                    queryDebounce = Task { @MainActor in
+                        try? await Task.sleep(nanoseconds: 200_000_000)
+                        recomputeRows()
+                    }
+                }
+                .onChange(of: viewModel.expandedPaths) { _ in
+                    recomputeRows()
+                }
+                .onChange(of: root?.id) { _ in
+                    recomputeRows()
+                }
                 .onAppear {
                     // Do not focus search by default
                     findFocused = false
@@ -170,6 +198,7 @@ struct JSONTreeView: View {
                     if viewModel.expandedPaths.isEmpty {
                         viewModel.expandedPaths.insert("")
                     }
+                    recomputeRows()
                 }
             } else {
                 VStack(spacing: 6) {

--- a/JSONViewer/UI/SidebarView.swift
+++ b/JSONViewer/UI/SidebarView.swift
@@ -178,7 +178,7 @@ struct SidebarView: View {
         }
         .onChange(of: viewModel.searchText) { _ in
             if viewModel.jsonlIndex != nil {
-                viewModel.runSidebarSearch()
+                viewModel.runSidebarSearchDebounced()
             } else {
                 viewModel.sidebarFilteredRowIDs = nil
             }


### PR DESCRIPTION
This PR addresses performance issues when interacting with large JSONL files in the app. Significant changes were made to the JSONTreeView and SidebarView to implement debouncing on search operations, reducing UI lag during typing. 

In JSONTreeView, we now cache the results of row computations and debounce the recomputation of rows when the search query changes, preventing unnecessary heavy calculations on every keystroke. 

The SidebarView was updated to use a debounced search method, ensuring that the sidebar search operates efficiently without freezing the app.

These improvements should lead to a smoother user experience, particularly when dealing with large datasets.

---

> This pull request was co-created with Cosine Genie

Original Task: [JSONViewer/v5n2l9s1xx92](https://cosine.sh/8yzos59yg6yv/JSONViewer/task/v5n2l9s1xx92)
Author: Alistair Pullen
