### PR TITLE
Fix Crash on Live Reloading with Invalid Range

### DIFF
--- a/JSONViewer/Core/JSONL/JSONLIndex.swift
+++ b/JSONViewer/Core/JSONL/JSONLIndex.swift
@@ -107,8 +107,12 @@ final class JSONLIndex {
     }
 
     func sliceRange(forLine index: Int) -> Range<UInt64>? {
-        guard index >= 0 && index + 1 < offsets.count else { return nil }
-        return offsets[index]..<offsets[index + 1]
+        let local = offsets
+        guard index >= 0 && index + 1 < local.count else { return nil }
+        let start = local[index]
+        let end = local[index + 1]
+        guard start <= end else { return nil }
+        return start..<end
     }
 
     func readLine(at index: Int, maxBytes: Int? = nil) throws -> String? {


### PR DESCRIPTION
This PR addresses a crash issue that occurred when a new line is added during live reloading. The `sliceRange(forLine:)` function has been updated to include an additional check to ensure that the start of the range is less than or equal to the end. This prevents the fatal error `Range requires lowerBound <= upperBound`, thereby ensuring stability when lines are updated.

---

> This pull request was co-created with Cosine Genie

Original Task: [JSONViewer/6jsg1up4nxdj](https://cosine.sh/8yzos59yg6yv/JSONViewer/task/6jsg1up4nxdj)
Author: Alistair Pullen
